### PR TITLE
Use non-deprecated vars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "openstack_networking_secgroup_rule_v2" "rule_ssh_access_ipv6" {
 
 # Allow icmp from IPv4 net
 resource "openstack_networking_secgroup_rule_v2" "rule_icmp_access_ipv4" {
-  count             = length(var.allow_ssh_from_v4)
+  count             = length(var.allow_icmp_from_v4)
   region            = var.region
   direction         = "ingress"
   ethertype         = "IPv4"
@@ -54,7 +54,7 @@ resource "openstack_networking_secgroup_rule_v2" "rule_icmp_access_ipv4" {
 
 # Allow icmp from IPv6 net
 resource "openstack_networking_secgroup_rule_v2" "rule_icmp_access_ipv6" {
-  count             = length(var.allow_ssh_from_v6)
+  count             = length(var.allow_icmp_from_v6)
   region            = var.region
   direction         = "ingress"
   ethertype         = "IPv6"

--- a/output.tf
+++ b/output.tf
@@ -7,7 +7,7 @@ variable "search" {
 }
 
 data "template_file" "ansible_host_v6" {
-  template = "$${name} ansible_host=$${ip} ansible_ssh_user=$${user}"
+  template = "$${name} ansible_host=$${ip} ansible_user=$${user}"
   count    = length(var.gold_images) * var.ncount
   vars = {
     ip = replace(
@@ -31,7 +31,7 @@ data "template_file" "ansible_host_v6" {
 }
 
 data "template_file" "ansible_host_v4" {
-  template = "$${name} ansible_host=$${ip} ansible_ssh_user=$${user}"
+  template = "$${name} ansible_host=$${ip} ansible_user=$${user}"
   count    = length(var.gold_images) * var.ncount
   vars = {
     ip = element(


### PR DESCRIPTION
Ansible 2.0 has deprecated the “ssh” from ansible_ssh_user, ansible_ssh_host, and ansible_ssh_port to become ansible_user, ansible_host, and ansible_port. If you are using a version of Ansible prior to 2.0, you should continue using the older style variables (ansible_ssh_*). These shorter variables are ignored, without warning, in older versions of Ansible.